### PR TITLE
Update 0.11.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-channel:
+channels:
   - https://staging.continuum.io/prefect/fs/pytest-trio-feedstock/pr1/8270277

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channel:
+  - https://staging.continuum.io/prefect/fs/pytest-trio-feedstock/pr1/8270277

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/pytest-trio-feedstock/pr1/8270277

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,6 @@ test:
     - trio_websocket
   commands:
     - pip check
-    - pytest -vv --cov trio_websocket --cov-report term-missing:skip-covered --no-cov-on-fail --cov-fail-under 95
   requires:
     - attrs >=19.2.0
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ test:
     - pip
     - pytest >=4.6
     - trustme
-    - pytest-cov
+    # - pytest-cov
     # - pytest-trio >=0.5.0
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,7 @@ test:
     - trio_websocket
   commands:
     - pip check
+    - pytest -vv --cov trio_websocket --cov-report term-missing:skip-covered --no-cov-on-fail --cov-fail-under 95 # [not arm64]
   requires:
     - attrs >=19.2.0
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
   host:
     - pip
     - python
+    - wheel
   run:
     - python
     - trio >=0.11
@@ -35,11 +36,14 @@ test:
     - trio_websocket
   commands:
     - pip check
+    - pytest -vv --cov trio_websocket --cov-report term-missing:skip-covered --no-cov-on-fail --cov-fail-under 95
   requires:
     - attrs >=19.2.0
     - pip
     - pytest >=4.6
     - trustme
+    - pytest-cov
+    # - pytest-trio >=0.5.0
 
 about:
   home: https://github.com/HyperionGray/trio-websocket
@@ -51,7 +55,9 @@ about:
     I/O library.
   # TODO: revisit if/after merge of https://github.com/HyperionGray/trio-websocket/pull/168
   license_file: LICENSE
+  license_family: MIT
   doc_url: https://trio-websocket.readthedocs.io
+  dev_url: https://github.com/HyperionGray/trio-websocket
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,6 @@ test:
     - pip
     - pytest >=4.6
     - trustme
-    - pytest-cov
     - pytest-trio >=0.5.0
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,16 +5,12 @@ package:
   version: {{ version }}
 
 source:
-  # - folder: dist
-  #   url: https://pypi.io/packages/source/t/trio-websocket/trio-websocket-{{ version }}.tar.gz
-  #   sha256: 18c11793647703c158b1f6e62de638acada927344d534e3c7628eedcb746839f
-  # - folder: src
     url: https://github.com/HyperionGray/trio-websocket/archive/refs/tags/{{ version }}.tar.gz
     sha256: 31b33561be82ea8f748ca2d8adaf3c45a2003c1a5e1550d7cf44e5a884564bce
 
 build:
   number: 0
-  skip: True  # [py<38]
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ test:
     - trio_websocket
   commands:
     - pip check
-    - cd src && pytest -vv --cov trio_websocket --cov-report term-missing:skip-covered --no-cov-on-fail --cov-fail-under 95
+    - pytest -vv --cov trio_websocket --cov-report term-missing:skip-covered --no-cov-on-fail --cov-fail-under 95
   requires:
     - attrs >=19.2.0
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.9.2" %}
+{% set version = "0.11.1" %}
 
 package:
   name: trio-websocket
@@ -7,25 +7,25 @@ package:
 source:
   - folder: dist
     url: https://pypi.io/packages/source/t/trio-websocket/trio-websocket-{{ version }}.tar.gz
-    sha256: a3d34de8fac26023eee701ed1e7bf4da9a8326b61a62934ec9e53b64970fd8fe
+    sha256: 18c11793647703c158b1f6e62de638acada927344d534e3c7628eedcb746839f
   - folder: src
     url: https://github.com/HyperionGray/trio-websocket/archive/refs/tags/{{ version }}.tar.gz
-    sha256: acc72db00e89e4594caac269aabebeccbd7b2d87d4dd06acba7adf4344cd8a42
+    sha256: 31b33561be82ea8f748ca2d8adaf3c45a2003c1a5e1550d7cf44e5a884564bce
 
 build:
   number: 0
-  noarch: python
-  script: cd dist && {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
 requirements:
   host:
     - pip
-    - python >=3.5
+    - python
   run:
-    - async_generator >=1.10
-    - python >=3.5
+    - python
     - trio >=0.11
     - wsproto >=0.14
+    - exceptiongroup # [py<311]
 
 test:
   source_files:
@@ -40,14 +40,16 @@ test:
     - attrs >=19.2.0
     - pip
     - pytest >=4.6
-    - pytest-cov
-    - pytest-trio >=0.5.0
     - trustme
 
 about:
   home: https://github.com/HyperionGray/trio-websocket
   summary: WebSocket library for Trio
   license: MIT
+  description: |
+    trio-websocket is a WebSocket library for Trio. It is a port of the
+    wsproto library to Trio, and is designed to be used with the Trio async
+    I/O library.
   # TODO: revisit if/after merge of https://github.com/HyperionGray/trio-websocket/pull/168
   license_file: src/LICENSE
   doc_url: https://trio-websocket.readthedocs.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ test:
   commands:
     - pip check
     - pytest -vv  # [not arm64]
+    ## Skipped tests on osx-arm64 due to our CI limitations with networking libraries
   requires:
     - attrs >=19.2.0
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
     - trio_websocket
   commands:
     - pip check
-    - pytest -vv --cov trio_websocket --cov-report term-missing:skip-covered --no-cov-on-fail --cov-fail-under 95 # [not arm64]
+    - pytest -vv  # [not arm64]
   requires:
     - attrs >=19.2.0
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,8 +42,8 @@ test:
     - pip
     - pytest >=4.6
     - trustme
-    # - pytest-cov
-    # - pytest-trio >=0.5.0
+    - pytest-cov
+    - pytest-trio >=0.5.0
 
 about:
   home: https://github.com/HyperionGray/trio-websocket

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,10 +5,10 @@ package:
   version: {{ version }}
 
 source:
-  - folder: dist
-    url: https://pypi.io/packages/source/t/trio-websocket/trio-websocket-{{ version }}.tar.gz
-    sha256: 18c11793647703c158b1f6e62de638acada927344d534e3c7628eedcb746839f
-  - folder: src
+  # - folder: dist
+  #   url: https://pypi.io/packages/source/t/trio-websocket/trio-websocket-{{ version }}.tar.gz
+  #   sha256: 18c11793647703c158b1f6e62de638acada927344d534e3c7628eedcb746839f
+  # - folder: src
     url: https://github.com/HyperionGray/trio-websocket/archive/refs/tags/{{ version }}.tar.gz
     sha256: 31b33561be82ea8f748ca2d8adaf3c45a2003c1a5e1550d7cf44e5a884564bce
 
@@ -29,8 +29,8 @@ requirements:
 
 test:
   source_files:
-    - src/pytest.ini
-    - src/tests
+    - pytest.ini
+    - tests
   imports:
     - trio_websocket
   commands:
@@ -51,7 +51,7 @@ about:
     wsproto library to Trio, and is designed to be used with the Trio async
     I/O library.
   # TODO: revisit if/after merge of https://github.com/HyperionGray/trio-websocket/pull/168
-  license_file: src/LICENSE
+  license_file: LICENSE
   doc_url: https://trio-websocket.readthedocs.io
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,6 @@ test:
     - trio_websocket
   commands:
     - pip check
-    - pytest -vv --cov trio_websocket --cov-report term-missing:skip-covered --no-cov-on-fail --cov-fail-under 95
   requires:
     - attrs >=19.2.0
     - pip


### PR DESCRIPTION
## ☆ Trio-websocket Update 0.11.1 ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-5420)
[Upstream](https://github.com/HyperionGray/trio-websocket)

### Changes
 - Updated version number and sha256
 - Removed the dist folder and adjusted the URL to point directly to the GitHub repository tarball.
 - Updated the source file paths in the tests section to ensure correct referencing (pytest.ini and tests).
- Added `exceptiongroup` to the run requirements for Python versions below 3.11.
- Updated pytest command to exclude the `arm641` architecture from certain test coverage checks due to CI limitations with networking libraries, as advised
- Removed unnecessary cd src command in testing.
- Updated `about` section