### PR TITLE
trio-websocket 0.12.2 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
-
-channels:
-- https://staging.continuum.io/prefect/fs/outcome-feedstock/pr1/813fb5f
-- https://staging.continuum.io/prefect/fs/pytest-trio-feedstock/pr2/c5a72ec

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,4 @@ build_env_vars:
 
 channels:
 - https://staging.continuum.io/prefect/fs/outcome-feedstock/pr1/813fb5f
+- https://staging.continuum.io/prefect/fs/pytest-trio-feedstock/pr2/c5a72ec

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes
+
+channels:
+- https://staging.continuum.io/prefect/fs/outcome-feedstock/pr1/813fb5f

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ test:
     - trio_websocket
   commands:
     - pip check
-    - pytest -vv  # [not arm64 and win]
+    - pytest -vv  # [not (arm64 or win)]
     ## Skipped tests on osx-arm64 and win due to our CI limitations with networking libraries
   requires:
     - attrs >=19.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,8 +35,7 @@ test:
   commands:
     - pip check
     - pytest -vv  # [not arm64 and win]
-    - pytest -vv . -k "not test_client_close_timeout"  # [win]
-    ## Skipped tests on osx-arm64 due to our CI limitations with networking libraries
+    ## Skipped tests on osx-arm64 and win due to our CI limitations with networking libraries
   requires:
     - attrs >=19.2.0
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,17 @@
-{% set version = "0.11.1" %}
+{% set name = "trio-websocket" %}
+{% set version = "0.12.2" %}
 
 package:
-  name: trio-websocket
+  name: {{ name }}
   version: {{ version }}
 
 source:
-    url: https://github.com/HyperionGray/trio-websocket/archive/refs/tags/{{ version }}.tar.gz
-    sha256: 31b33561be82ea8f748ca2d8adaf3c45a2003c1a5e1550d7cf44e5a884564bce
+    url: https://github.com/HyperionGray/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+    sha256: 4784c823dbe98e4dc3909b560857c64f5786bca01d00d16f2e3ae37a32a54174
 
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
 requirements:
@@ -23,6 +24,7 @@ requirements:
     - trio >=0.11
     - wsproto >=0.14
     - exceptiongroup # [py<311]
+    - outcome >=1.2.0
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,8 @@ test:
     - trio_websocket
   commands:
     - pip check
-    - pytest -vv  # [not arm64]
+    - pytest -vv  # [not arm64 and win]
+    - pytest -vv . -k "not test_client_close_timeout"  # [win]
     ## Skipped tests on osx-arm64 due to our CI limitations with networking libraries
   requires:
     - attrs >=19.2.0


### PR DESCRIPTION
trio-websocket 0.12.2 

**Destination channel:** Defaults

### Links

- [PKG-7153]
- dev_url:        https://github.com/HyperionGray/trio-websocket/tree/0.12.2
- conda_forge:    https://github.com/conda-forge/trio-websocket-feedstock
- pypi:           https://pypi.org/project/trio-websocket/0.12.2
- pypi inspector: https://inspector.pypi.io/project/trio-websocket/0.12.2

### Explanation of changes:

- new version number
- dependency update PR's:
    - https://github.com/AnacondaRecipes/outcome-feedstock/pull/1
    - https://github.com/AnacondaRecipes/pytest-trio-feedstock/pull/2

[PKG-7153]: https://anaconda.atlassian.net/browse/PKG-7153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ